### PR TITLE
Update ejabberd_c2s_types' ipv4/v6 switch

### DIFF
--- a/ejabberd_c2s_types
+++ b/ejabberd_c2s_types
@@ -5,6 +5,7 @@
 
 import subprocess
 import sys
+import ipaddr
 
 if 'autoconf' in sys.argv:
     print('yes')
@@ -57,7 +58,8 @@ for line in stdout:
     if 'compressed' in conn:
         compressed += 1
 
-    if ip.startswith('::FFFF:'):
+    addrx = ipaddr.IPAddress(ip)
+    if addrx.version == 4:
         ipv4 += 1
     else:
         ipv6 += 1


### PR DESCRIPTION
Somethings v4 addresses don't start with ::FFFF: ;-)

P.S.: the former version might still be needed on servers that see IPv4 as ::FFFF:...

P.P.S.: `apt-get install python3-ipaddr`
